### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ print 'Debug:'
 print h2c.debug_vars()
 print '---------'
 
-result = h2c.request()
+result = h2c.result()
 
 print 'mime: ' + result['mime']
 print 'data: ' + result['data']


### PR DESCRIPTION
In the python example, shouldn't it be `.result()`, there is no definition for `.request()` in `html2canvasproxy.py`